### PR TITLE
showing equipment targets on tab/tab2

### DIFF
--- a/duel.py
+++ b/duel.py
@@ -24,6 +24,7 @@ QUERY_CODE = 1
 QUERY_POSITION = 0x2
 QUERY_ATTACK = 0x100
 QUERY_DEFENSE = 0x200
+QUERY_EQUIP_CARD = 0x4000
 QUERY_COUNTERS = 0x20000
 
 TYPE_FUSION = 0x40
@@ -771,7 +772,7 @@ class Duel:
 
 	def get_cards_in_location(self, player, location):
 		cards = []
-		flags = QUERY_CODE | QUERY_POSITION | QUERY_ATTACK | QUERY_DEFENSE | QUERY_COUNTERS
+		flags = QUERY_CODE | QUERY_POSITION | QUERY_ATTACK | QUERY_DEFENSE | QUERY_EQUIP_CARD | QUERY_COUNTERS
 		bl = lib.query_field_card(self.duel, player, location, flags, ffi.cast('byte *', self.buf), False)
 		buf = io.BytesIO(ffi.unpack(self.buf, bl))
 		while True:
@@ -787,6 +788,17 @@ class Duel:
 			card.set_location(position)
 			card.attack = self.read_u32(buf)
 			card.defense = self.read_u32(buf)
+
+			card.equip_target = None
+
+			if f & QUERY_EQUIP_CARD == QUERY_EQUIP_CARD: # optional
+
+				equip_target = self.read_u32(buf)
+				pl = equip_target & 0xff
+				loc = (equip_target >> 8) & 0xff
+				seq = (equip_target >> 16) & 0xff
+				card.equip_target = self.get_card(pl, loc, seq)
+
 			cs = self.read_u32(buf)
 			card.counters = []
 			for i in range(cs):

--- a/server.py
+++ b/server.py
@@ -879,6 +879,11 @@ class MyDuel(dm.Duel):
 			else:
 				s += card.get_name(con) + " "
 				s += card.get_position(con)
+
+				if card.equip_target:
+
+					s += ' ' + con._('(equipped to %s)')%(self.card_to_spec(con.duel_player, card.equip_target))
+
 			con.notify(s)
 
 	def show_cards_in_location(self, con, player, location, hide_facedown=False):


### PR DESCRIPTION
title says it all. when typing tab/tab2, cards in spell/trap zone will show their current equipment target (if they are equipping another card at the moment)