### PR TITLE
supporting deck top and reverse deck events

### DIFF
--- a/duel.py
+++ b/duel.py
@@ -181,6 +181,8 @@ class Duel:
 		2: self.msg_hint,
 		18: self.msg_select_place,
 		24: self.msg_select_place,
+		37: self.msg_reversedeck,
+		38: self.msg_decktop,
 		50: self.msg_move,
 		56: self.msg_field_disabled,
 		60: self.msg_summoning,
@@ -260,6 +262,21 @@ class Duel:
 				print("msg %d unhandled" % msg)
 				data = b''
 		return data
+
+	def msg_reversedeck(self, data):
+		for pl in self.players+self.watchers:
+			pl.notify(pl._("all decks are now reversed."))
+		return data[1:]
+
+	def msg_decktop(self, data):
+		data = io.BytesIO(data[1:])
+		player = self.read_u8(data)
+		self.read_u8(data) # don't know what this number does
+		code = self.read_u32(data)
+		if code & 0x80000000:
+			code = code ^ 0x80000000 # don't know what this actually does
+		self.cm.call_callbacks('decktop', player, Card.from_code(code))
+		return data.read()
 
 	def msg_draw(self, data):
 		data = io.BytesIO(data[1:])

--- a/server.py
+++ b/server.py
@@ -340,7 +340,7 @@ class MyDuel(dm.Duel):
 			if pl is player:
 				pl.notify(pl._("you reveal your top deck card to be %s")%(card.get_name(pl)))
 			else:
-				pl.notify(pl._("%s reveals his top deck card to be %s")%(player.nickname, card.get_name(pl)))
+				pl.notify(pl._("%s reveals their top deck card to be %s")%(player.nickname, card.get_name(pl)))
 
 	def draw(self, player, cards):
 		pl = self.players[player]

--- a/server.py
+++ b/server.py
@@ -294,6 +294,7 @@ class MyDuel(dm.Duel):
 		self.cm.register_callback('attack', self.attack)
 		self.cm.register_callback('begin_damage', self.begin_damage)
 		self.cm.register_callback('end_damage', self.end_damage)
+		self.cm.register_callback('decktop', self.decktop)
 		self.cm.register_callback('battle', self.battle)
 		self.cm.register_callback('damage', self.damage)
 		self.cm.register_callback('hint', self.hint)
@@ -332,6 +333,14 @@ class MyDuel(dm.Duel):
 		self.players = [None, None]
 		self.lp = [8000, 8000]
 		self.started = False
+
+	def decktop(self, player, card):
+		player = self.players[player]
+		for pl in self.players+self.watchers:
+			if pl is player:
+				pl.notify(pl._("you reveal your top deck card to be %s")%(card.get_name(pl)))
+			else:
+				pl.notify(pl._("%s reveals his top deck card to be %s")%(player.nickname, card.get_name(pl)))
 
 	def draw(self, player, cards):
 		pl = self.players[player]


### PR DESCRIPTION
* cards like convulsion of nature turn the deck around, resulting in deck reverse (37) message
* also, deck top (38) messages will be triggered whenever the top-most card of the deck changes (after drawing, after searching cards from the deck etc)