### PR TITLE
add hand2 command

### DIFF
--- a/ygo/duel.py
+++ b/ygo/duel.py
@@ -530,8 +530,9 @@ class Duel:
 			if hide_facedown and card.position in (POS_FACEDOWN_DEFENSE, POS_FACEDOWN):
 				s += card.get_position(pl)
 			else:
-				s += card.get_name(pl) + " "
-				s += card.get_position(pl)
+				s += card.get_name(pl)
+				if location != LOCATION_HAND:
+					s += " " + card.get_position(pl)
 				if card.type & TYPE_MONSTER:
 					s += " " + pl._("level %d") % card.level
 			pl.notify(s)

--- a/ygo/duel.py
+++ b/ygo/duel.py
@@ -523,11 +523,11 @@ class Duel:
 	def show_cards_in_location(self, pl, player, location, hide_facedown=False):
 		cards = self.get_cards_in_location(player, location)
 		if not cards:
-			pl.notify(pl._("Table is empty."))
+			pl.notify(pl._("No cards."))
 			return
 		for card in cards:
 			s = card.get_spec(player) + " "
-			if hide_facedown and card.position in (0x8, 0xa):
+			if hide_facedown and card.position in (POS_FACEDOWN_DEFENSE, POS_FACEDOWN):
 				s += card.get_position(pl)
 			else:
 				s += card.get_name(pl) + " "
@@ -535,14 +535,6 @@ class Duel:
 				if card.type & TYPE_MONSTER:
 					s += " " + pl._("level %d") % card.level
 			pl.notify(s)
-
-	def show_hand(self, pl, player):
-		h = self.get_cards_in_location(player, LOCATION_HAND)
-		if not h:
-			pl.notify(pl._("Your hand is empty."))
-			return
-		for c in h:
-			pl.notify("h%d: %s" % (c.sequence + 1, c.get_name(pl)))
 
 	def show_score(self, pl):
 		player = pl.duel_player

--- a/ygo/parsers/duel_parser.py
+++ b/ygo/parsers/duel_parser.py
@@ -9,9 +9,12 @@ DuelParser = gsb.Parser(command_substitutions = COMMAND_SUBSTITUTIONS)
 @DuelParser.command(names=['h', 'hand'])
 def hand(caller):
 	pl = caller.connection.player
-	if pl.watching:
-		return
-	pl.duel.show_hand(pl, pl.duel_player)
+	pl.duel.show_cards_in_location(pl, pl.duel_player, LOCATION_HAND, pl.watching)
+
+@DuelParser.command(names=['h2', 'hand2'])
+def hand2(caller):
+
+	caller.connection.player.duel.show_cards_in_location(caller.connection.player, 1 - caller.connection.player.duel_player, LOCATION_HAND, True)
 
 @DuelParser.command(names=['tab'])
 def tab(caller):

--- a/ygo/parsers/duel_parser.py
+++ b/ygo/parsers/duel_parser.py
@@ -11,7 +11,7 @@ def hand(caller):
 	pl = caller.connection.player
 	pl.duel.show_cards_in_location(pl, pl.duel_player, LOCATION_HAND, pl.watching)
 
-@DuelParser.command(names=['h2', 'hand2'])
+@DuelParser.command(names=['hand2'])
 def hand2(caller):
 
 	caller.connection.player.duel.show_cards_in_location(caller.connection.player, 1 - caller.connection.player.duel_player, LOCATION_HAND, True)


### PR DESCRIPTION
Cards like Eye of Truth require a command which shows the opponent's hand. Hand2 does exactly that.
Additionally, removed show_hand() method from Duel class, using show_cards_in_location() instead.