### PR TITLE
using duel parser whenever in a duel

### DIFF
--- a/ygo/duel.py
+++ b/ygo/duel.py
@@ -627,12 +627,9 @@ class Duel:
 			self.pause()
 
 	def player_reconnected(self, pl):
+		pl.set_parser('DuelParser')
 		if not self.paused:
-			# all players returned successfully
 			self.unpause()
-		else:
-			# the player returned, but there are players left who need to reconnect
-			pl.set_parser('LobbyParser')
 
 	def pause(self):
 		for pl in self.players + self.watchers:
@@ -640,20 +637,12 @@ class Duel:
 		for pl in self.players+self.tag_players:
 			if pl.connection is not None:
 				pl.paused_parser = pl.connection.parser
-				pl.set_parser('LobbyParser')
-
-		for w in self.watchers:
-			if w.watching is True:
-				w.set_parser('LobbyParser')
+				pl.set_parser('DuelParser')
 
 	def unpause(self):
 		for pl in self.players+self.tag_players:
 			pl.connection.parser = pl.paused_parser
 			pl.paused_parser = None
-		for w in self.watchers:
-			if w.watching is True:
-				w.set_parser('DuelParser')
-
 		for pl in self.players+self.watchers:
 			pl.notify(pl._("Duel continues."))
 
@@ -685,10 +674,9 @@ class Duel:
 		self.watchers.append(pl)
 		self.watch.send_message(pl, __("{player} is now watching this duel."))
 		self.watch.add_recipient(pl)
+		pl.set_parser('DuelParser')
 		if self.paused:
 			pl.notify(pl._("The duel is currently paused due to not all players being connected."))
-		else:
-			pl.set_parser('DuelParser')
 
 	def get_linked_zone(self, card):
 

--- a/ygo/parsers/duel_parser.py
+++ b/ygo/parsers/duel_parser.py
@@ -83,3 +83,25 @@ def show_watchers(caller):
 @DuelParser.command(names=['info'], args_regexp=r'(.*)')
 def info(caller):
 	caller.connection.player.duel.show_info_cmd(caller.connection.player, caller.args[0])
+
+@DuelParser.command(names=['giveup'], allowed = lambda c: c.connection.player.watching is False)
+def giveup(caller):
+
+	duel = caller.connection.player.duel
+
+	for pl in duel.players+duel.watchers:
+		pl.notify(pl._("%s has ended the duel.")%(caller.connection.player.nickname))
+
+	if not duel.private:
+		if duel.tag is True:
+			op = "team "+duel.players[1 - caller.connection.player.duel_player].nickname+", "+duel.tag_players[1 - caller.connection.player.duel_player].nickname
+		else:
+			op = duel.players[1 - caller.connection.player.duel_player].nickname
+		globals.server.challenge.send_message(None, __("{player1} has cowardly submitted to {player2}."), player1 = caller.connection.player.nickname, player2 = op)
+
+	duel.end()
+
+# watchers and duelists in paused games need to see them too
+@DuelParser.command(names=['sc', 'score'])
+def score(caller):
+	caller.connection.player.duel.show_score(caller.connection.player)

--- a/ygo/parsers/lobby_parser.py
+++ b/ygo/parsers/lobby_parser.py
@@ -452,11 +452,6 @@ def reboot(caller):
 	globals.rebooting = True
 	globals.server.check_reboot()
 
-# watchers and duelists in paused games need to see them too
-@LobbyParser.command(names=['sc', 'score'], allowed = lambda c: c.connection.player.duel is not None)
-def score(caller):
-	caller.connection.player.duel.show_score(caller.connection.player)
-
 @LobbyParser.command(args_regexp=r'(.*)')
 def echo(caller):
 	caller.connection.notify(caller.args[0])
@@ -506,23 +501,6 @@ def join(caller):
 	else:
 		target.room.join(pl)
 		caller.connection.parser.prompt(caller.connection)
-
-@LobbyParser.command(names=['giveup'], allowed = lambda c: c.connection.player.duel is not None)
-def giveup(caller):
-
-	duel = caller.connection.player.duel
-
-	for pl in duel.players+duel.watchers:
-		pl.notify(pl._("%s has ended the duel.")%(caller.connection.player.nickname))
-
-	if not duel.private:
-		if duel.tag is True:
-			op = "team "+duel.players[1 - caller.connection.player.duel_player].nickname+", "+duel.tag_players[1 - caller.connection.player.duel_player].nickname
-		else:
-			op = duel.players[1 - caller.connection.player.duel_player].nickname
-		globals.server.challenge.send_message(None, __("{player1} has cowardly submitted to {player2}."), player1 = caller.connection.player.nickname, player2 = op)
-
-	duel.end()
 
 @LobbyParser.command(names=['uptime'])
 def uptime(caller):


### PR DESCRIPTION
Instead of switching between lobby and duel parser, for players and watchers alike, we'll now stack with the duel parser.