### PR TITLE
invitation can be sent to players who are currently in a duel, but no…

### DIFF
--- a/ygo/parsers/room_parser.py
+++ b/ygo/parsers/room_parser.py
@@ -364,7 +364,7 @@ def invite(caller):
 
 	target = players[0]
 
-	if target.duel is not None:
+	if target.duel is not None and (target in target.duel.players or target in target.duel.tag_players):
 		pl.notify(pl._("This player is already in a duel."))
 		return
 	elif target.room is not None:

--- a/ygo/room.py
+++ b/ygo/room.py
@@ -29,10 +29,8 @@ class Room:
 			self.invitations.remove(player.nickname)
 		for pl in self.get_all_players():
 			if pl is player:
-				if player is self.creator:
-					player.notify(player._("You joined your new room. You need to finish the setup to make it available to the other players."))
-				else:
-					pl.notify(pl._("You joined %s's room. Use the teams and move command to move yourself into a team, or stay outside of any team to watch the duel.")%(self.creator.nickname))
+				pl.notify(pl._("You joined %s's room. Use the teams and move command to move yourself into a team, or stay outside of any team to watch the duel.")%(self.creator.nickname))
+				self.show(pl)
 			else:
 				pl.notify(pl._("%s joined this room.")%(player.nickname))
 


### PR DESCRIPTION
…t duelling themselves (watchers)

closes #158
when joining a room, the current settings of that room are instantly shown