### PR TITLE
Fixes #217 - show pendulum scales in spell and trap zone

### DIFF
--- a/ygo/duel.py
+++ b/ygo/duel.py
@@ -553,8 +553,10 @@ class Duel(Joinable):
 				s += card.get_name(pl) + " "
 				s += card.get_position(pl)
 
-				if card.equip_target:
+				if card.type & TYPE.PENDULUM:
+					s += " (" + pl._("Pendulum scale: %d/%d") % (card.lscale, card.rscale) + ")"
 
+				if card.equip_target:
 					s += ' ' + pl._('(equipped to %s)')%(card.equip_target.get_spec(pl))
 
 				counters = []


### PR DESCRIPTION
As written in #217 this will show the pendulum scale (if any) when using the "tab" or "tab2" commands while in a duel.