### PR TITLE
Updated deck commands to be able to take ids when logically possible

### DIFF
--- a/ygo/deck_editor.py
+++ b/ygo/deck_editor.py
@@ -206,6 +206,9 @@ class DeckEditor:
 		if '=' in dest:
 			self.player.notify(self.player._("Deck names may not contain =."))
 			return
+		if dest.isdigit():
+			self.player.notify(self.player._("Deck names may not be numbers."))
+			return
 		account = self.player.get_account()
 		session = self.player.connection.session
 		deck = models.Deck.find(session, account, name)
@@ -232,6 +235,9 @@ class DeckEditor:
 			return
 		if '=' in dest:
 			self.player.notify(self.player._("Deck names may not contain =."))
+			return
+		if dest.isdigit():
+			self.player.notify(self.player._("Deck names may not be numbers."))
 			return
 
 		if '/' in dest:
@@ -379,6 +385,9 @@ class DeckEditor:
 
 		else:
 			con.notify(con._("Creating new deck %s.") % deck_name)
+			if deck_name.isdigit():
+				con.notify(self.player._("Deck names may not be numbers."))
+				return
 			con.player.deck = {'cards': [], 'side': []}
 		self.deck_name = deck_name
 		con.parser.prompt(con)
@@ -473,6 +482,9 @@ class DeckEditor:
 		deck = models.Deck.find(session, account, name)
 		if deck:
 			self.player.notify(self.player._("That deck already exists."))
+			return
+		if name.isdigit():
+			self.player.notify(self.player._("Deck names may not be numbers."))
 			return
 		deck = models.Deck(account_id=account.id, name=name)
 		account.decks.append(deck)

--- a/ygo/models.py
+++ b/ygo/models.py
@@ -70,7 +70,7 @@ class Deck(Base):
 	@staticmethod
 	def find_public(session, account, name):
 		if name.isdigit():
-			return session.query(Deck).filter_by(account_id=account.id, id=int(name), public = True).first()
+			return session.query(Deck).filter_by(id=int(name), public = True).first()
 		return session.query(Deck).filter_by(account_id=account.id, name=name, public = True).first()
 
 	@staticmethod

--- a/ygo/models.py
+++ b/ygo/models.py
@@ -63,10 +63,14 @@ class Deck(Base):
 
 	@staticmethod
 	def find(session, account, name):
+		if name.isdigit():
+			return session.query(Deck).filter_by(account_id=account.id, id=int(name)).first()
 		return session.query(Deck).filter_by(account_id=account.id, name=name).first()
 
 	@staticmethod
 	def find_public(session, account, name):
+		if name.isdigit():
+			return session.query(Deck).filter_by(account_id=account.id, id=int(name), public = True).first()
 		return session.query(Deck).filter_by(account_id=account.id, name=name, public = True).first()
 
 	@staticmethod

--- a/ygo/models.py
+++ b/ygo/models.py
@@ -64,7 +64,7 @@ class Deck(Base):
 	@staticmethod
 	def find(session, account, name):
 		if name.isdigit():
-			return session.query(Deck).filter_by(account_id=account.id, id=int(name)).first()
+			return session.query(Deck).filter_by(id=int(name)).first()
 		return session.query(Deck).filter_by(account_id=account.id, name=name).first()
 
 	@staticmethod


### PR DESCRIPTION
This pr adds the possibility to use deck ids in commands where it makes sense.
Notably it's possible to use deck ids in all commands except the destination deck name in deck copy and deck rename.