### PR TITLE
Fix wording of invite messages

### DIFF
--- a/locale/de/LC_MESSAGES/game.po
+++ b/locale/de/LC_MESSAGES/game.po
@@ -1782,7 +1782,7 @@ msgstr "%s ist abwesend und könnte Dich eventuell nicht bemerken."
 
 #: ygo/parsers/duel_parser.py:246
 #, python-format
-msgid "%s invites you to watch his duel. Type watch %s to do so."
+msgid "%s invites you to watch their duel. Type watch %s to do so."
 msgstr "%s lädt Dich ein, seinem Duell zuzusehen. Tippe watch %s, um die Einladung anzunehmen."
 
 #: ygo/parsers/duel_parser.py:248 ygo/parsers/room_parser.py:446
@@ -2498,7 +2498,7 @@ msgstr "Du kannst jeden Spieler in diesen Raum einladen. Tippe einfach invite Sp
 
 #: ygo/parsers/room_parser.py:444
 #, python-format
-msgid "%s invites you to join his duel room. Type join %s to do so."
+msgid "%s invites you to join their duel room. Type join %s to do so."
 msgstr "%s lädt Dich ein, seinem Duellraum beizutreten. Tippe join %s, um die Einladung anzunehmen."
 
 #: ygo/parsers/room_parser.py:450

--- a/locale/es/LC_MESSAGES/game.po
+++ b/locale/es/LC_MESSAGES/game.po
@@ -1567,7 +1567,7 @@ msgstr "%s está AFK y puede no estar prestando atención."
 
 #: ygo/parsers/duel_parser.py:219
 #, python-format
-msgid "%s invites you to watch his duel. Type watch %s to do so."
+msgid "%s invites you to watch their duel. Type watch %s to do so."
 msgstr "%s te invita a ver su duelo. Escribe watch %s para hacerlo."
 
 #: ygo/parsers/duel_parser.py:221 ygo/parsers/room_parser.py:397
@@ -2208,7 +2208,7 @@ msgstr ""
 
 #: ygo/parsers/room_parser.py:395
 #, python-format
-msgid "%s invites you to join his duel room. Type join %s to do so."
+msgid "%s invites you to join their duel room. Type join %s to do so."
 msgstr "%s te invita a entrar a su sala. Teclea join %s para unirte."
 
 #: ygo/parsers/room_parser.py:401

--- a/locale/fr/LC_MESSAGES/game.po
+++ b/locale/fr/LC_MESSAGES/game.po
@@ -2017,7 +2017,7 @@ msgstr "Ce joueur se prépare déjà à livrer un duel."
 
 #: ygo/parsers/room_parser.py:383
 #, python-format
-msgid "%s invites you to join his duel room. Type join %s to do so."
+msgid "%s invites you to join their duel room. Type join %s to do so."
 msgstr "%s vous invite à rejoindre sa salle de duel. Tapez join %s pour le faire."
 
 #: ygo/parsers/room_parser.py:385

--- a/locale/ja/LC_MESSAGES/game.po
+++ b/locale/ja/LC_MESSAGES/game.po
@@ -1733,7 +1733,7 @@ msgstr "%s はAFKなので、すぐには気がつかないかもしれません
 
 #: ygo/parsers/duel_parser.py:215
 #, python-format
-msgid "%s invites you to watch his duel. Type watch %s to do so."
+msgid "%s invites you to watch their duel. Type watch %s to do so."
 msgstr "%s から、このデュエルの観戦に招待されています。 watch %s で、デュエルを観戦できます。"
 
 #: ygo/parsers/duel_parser.py:217 ygo/parsers/room_parser.py:445
@@ -2445,7 +2445,7 @@ msgstr "誰でもプレイヤーを招待できます。 invite <プレイヤー
 
 #: ygo/parsers/room_parser.py:443
 #, python-format
-msgid "%s invites you to join his duel room. Type join %s to do so."
+msgid "%s invites you to join their duel room. Type join %s to do so."
 msgstr "%s からデュエルルームへの招待が届いています。 join %s で参加できます。"
 
 #: ygo/parsers/room_parser.py:449

--- a/locale/pt/LC_MESSAGES/game.po
+++ b/locale/pt/LC_MESSAGES/game.po
@@ -1782,7 +1782,7 @@ msgstr "%s está AUSENTE e pode não estar prestando atenção."
 
 #: ygo/parsers/duel_parser.py:246
 #, python-format
-msgid "%s invites you to watch his duel. Type watch %s to do so."
+msgid "%s invites you to watch their duel. Type watch %s to do so."
 msgstr "%s convida você para assistir seu duelo. Digite watch %s para fazê-lo."
 
 #: ygo/parsers/duel_parser.py:248 ygo/parsers/room_parser.py:448
@@ -2508,7 +2508,7 @@ msgstr "Você pode convidar qualquer jogador para entrar nesta sala. Simplesment
 
 #: ygo/parsers/room_parser.py:444
 #, python-format
-msgid "%s invites you to join his duel room. Type join %s to do so."
+msgid "%s invites you to join their duel room. Type join %s to do so."
 msgstr "%s convida você a se juntar à sua sala de duelo. Digite join %s para fazê-lo"
 
 #: ygo/parsers/room_parser.py:452

--- a/ygo/parsers/duel_parser.py
+++ b/ygo/parsers/duel_parser.py
@@ -273,7 +273,7 @@ def invite(caller):
 		if target.afk is True:
 			pl.notify(pl._("%s is AFK and may not be paying attention.")%(target.nickname))
 
-		target.notify(target._("%s invites you to watch his duel. Type watch %s to do so.")%(pl.nickname, pl.nickname))
+		target.notify(target._("%s invites you to watch their duel. Type watch %s to do so.")%(pl.nickname, pl.nickname))
 
 		pl.notify(pl._("An invitation was sent to %s.")%(target.nickname))
 

--- a/ygo/parsers/room_parser.py
+++ b/ygo/parsers/room_parser.py
@@ -454,7 +454,7 @@ def invite(caller):
 		if target.afk is True:
 			pl.notify(pl._("%s is AFK and may not be paying attention.")%(target.nickname))
 
-		target.notify(target._("%s invites you to join his duel room. Type join %s to do so.")%(pl.nickname, pl.nickname))
+		target.notify(target._("%s invites you to join their duel room. Type join %s to do so.")%(pl.nickname, pl.nickname))
 
 		pl.notify(pl._("An invitation was sent to %s.")%(target.nickname))
 


### PR DESCRIPTION
This PR fixes the wording of the invite messages for duelists and watchers.
We'll also need to update the soundpack at the same time.

