### PR TITLE
Remove showing of card set in get_info

### DIFF
--- a/ygo/card.py
+++ b/ygo/card.py
@@ -113,8 +113,6 @@ class Card(object):
 		elif self.type & TYPE.LINK:
 			lst.append(pl._("Link Markers: %s")%(self.get_link_markers(pl)))
 
-		lst.append(pl._("Set: {set}").format(set = self.get_set(pl)))
-
 		if pl.soundpack:
 			lst.append("### card_text_follows")
 


### PR DESCRIPTION
The card sets shown is first of all not accurate, and many players have indicated that it's not really relevant information to show anyway. Hence this PR to remove it.