### PR TITLE
Decreased disconnect timer

### DIFF
--- a/ygo/duel.py
+++ b/ygo/duel.py
@@ -712,7 +712,7 @@ class Duel(Joinable):
 				pl.paused_parser = pl.connection.parser
 				pl.set_parser('DuelParser')
 		if not self.pause_timer:
-			self.pause_timer = reactor.callLater(600, self.end, True)
+			self.pause_timer = reactor.callLater(300, self.end, True)
 
 	def unpause(self):
 		for pl in self.players+self.tag_players:


### PR DESCRIPTION
Players have indicated that 10 minutes is a long time to wait after a player disconnects from a duel to wait. This pr lowers that time down to 5 minutes.

The rationale:

* Most players use this for ill intents, disconnecting when they are about to lose a duel, with no intention of coming back
* The players that legitimately lose connection, should and will most likely be able to reconnect within the timelimit of 5 minutes.
